### PR TITLE
ログイン状態管理処理とイベント登録処理(events#create)の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ group :development, :test do
   # Use RSpec to test
   gem 'rspec-rails'
 
+  # Use FactoryGirl to create models
+  gem 'factory_girl_rails'
+
   # Use capybara to test capybara
   gem 'shoulda-matchers'
   gem 'capybara'

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,12 @@ group :development, :test do
   # Use capybara to test capybara
   gem 'shoulda-matchers'
   gem 'capybara'
+
+  # use pry
+  gem 'pry-rails'  # rails console(もしくは、rails c)でirbの代わりにpryを使われる
+  gem 'pry-doc'    # methodを表示
+  gem 'pry-byebug' # デバッグを実施(Ruby 2.0以降で動作する)
+  gem 'pry-stack_explorer' # スタックをたどれる
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -77,6 +78,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -95,6 +97,21 @@ GEM
     omniauth-twitter (1.2.1)
       json (~> 1.3)
       omniauth-oauth (~> 1.1)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
+    pry-doc (0.8.0)
+      pry (~> 0.9)
+      yard (~> 0.8)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
+    pry-stack_explorer (0.4.9.2)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -154,6 +171,7 @@ GEM
       rdoc (~> 4.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    slop (3.6.0)
     spring (1.7.1)
     sprockets (3.6.0)
       concurrent-ruby (~> 1.0)
@@ -179,6 +197,7 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    yard (0.8.7.6)
 
 PLATFORMS
   ruby
@@ -191,6 +210,10 @@ DEPENDENCIES
   jquery-rails
   omniauth
   omniauth-twitter
+  pry-byebug
+  pry-doc
+  pry-rails
+  pry-stack_explorer
   rails (= 4.2.6)
   rspec-rails
   sass-rails (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,11 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.4)
@@ -206,6 +211,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.1.0)
+  factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
   omniauth

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,9 @@ class ApplicationController < ActionController::Base
   def logged_in?
     !!session[:user_id]
   end
+  
+  def authenticate
+    return if logged_in?
+    redirect_to root_path, alert: 'ログインしてください'
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,14 +3,19 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  helper_method :logged_in?
+  helper_method :current_user, :logged_in?
 
   private
+
+  def current_user
+    return unless session[:user_id]
+    @current_user ||= User.find(session[:user_id])
+  end
 
   def logged_in?
     !!session[:user_id]
   end
-  
+
   def authenticate
     return if logged_in?
     redirect_to root_path, alert: 'ログインしてください'

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,2 +1,4 @@
 class EventsController < ApplicationController
+  def new
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,6 +13,9 @@ class EventsController < ApplicationController
     end
   end
 
+  def show
+  end
+
   private
 
   def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,7 +9,7 @@ class EventsController < ApplicationController
     if @event.save
       redirect_to @event, notice: '作成しました'
     else
-      render :new
+      render :new, status: 400
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,4 +3,7 @@ class EventsController < ApplicationController
 
   def new
   end
+
+  def create
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,6 @@
 class EventsController < ApplicationController
+  before_action :authenticate
+
   def new
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -5,5 +5,19 @@ class EventsController < ApplicationController
   end
 
   def create
+    @event = current_user.created_events.build(event_params)
+    if @event.save
+      redirect_to @event, notice: '作成しました'
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(
+      :name, :place, :content, :start_time, :end_time
+    )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  has_many :created_events, class_name: 'Event', foreign_key: :owner_id
+
   def self.find_or_create_from_auth_hash(auth_hash)
     provider = auth_hash[:provider]
     uid = auth_hash[:uid]

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
-
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -21,18 +21,19 @@ RSpec.describe EventsController, type: :controller do
           image_url: 'http://example.jp/image.jpg'
         )
         session[:user_id] = user.id
-      end
-      let(:end_time) { Date.today }
 
-      context '有効なイベントを作成しようとしたとき' do
-        it '#show にリダイレクトすること' do
-          post :create, event: {
+        post :create, event: {
             name: 'testname',
             place: 'testplace',
             content: 'testcontent',
             start_time: end_time - 1.days,
             end_time: end_time
           }
+      end
+      let(:end_time) { Date.today }
+
+      context '有効なイベントを作成しようとしたとき' do
+        it '#show にリダイレクトすること' do
           expect(response).to redirect_to event_path(assigns[:event])
         end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe EventsController, type: :controller do
           expect(response).to redirect_to event_path(assigns[:event])
         end
 
-        it 'notice を渡していること' do
+        it '#show で"作成しました"というメッセージを表示すること' do
           expect(session['flash']['flashes']['notice']).to eq '作成しました'
         end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -66,7 +66,9 @@ RSpec.describe EventsController, type: :controller do
             image_url: 'http://example.jp/image.jpg'
           )
           session[:user_id] = user.id
+        end
 
+        it '#new を再描画すること' do
           post :create, event: {
             name: '',
             place: '',
@@ -74,10 +76,30 @@ RSpec.describe EventsController, type: :controller do
             start_time: nil,
             end_time: nil
           }
+          expect(response).to render_template :new
         end
 
-        it '#new に遷移すること' do
-          expect(response).to redirect_to new_event_path
+        it 'ステータスコードとして400が返ってくること' do
+          post :create, event: {
+            name: '',
+            place: '',
+            content: '',
+            start_time: nil,
+            end_time: nil
+          }
+          expect(response.status).to eq 400
+        end
+
+        it 'イベントがデータベースに追加されていないこと' do
+          expect{
+            post :create, event: {
+            name: '',
+            place: '',
+            content: '',
+            start_time: nil,
+            end_time: nil
+            }
+          }.not_to change(Event, :count)
         end
       end
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,4 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
+  describe 'GET #new' do
+    context '未ログインユーザがアクセスしたとき' do
+      before { get :new }
+
+      it 'トップページにリダイレクトすること' do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe EventsController, type: :controller do
     describe '正常系' do
       context '有効なイベントを作成しようとしたとき' do
         it '#show にリダイレクトすること' do
+          post :create, event: {
+            name: 'testname',
+            place: 'testplace',
+            content: 'testcontent',
+            start_time: end_time - 1.days,
+            end_time: end_time
+          }
+          expect(response).to redirect_to event_path(assigns[:event])
         end
 
         it 'notice を渡していること' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -57,7 +57,15 @@ RSpec.describe EventsController, type: :controller do
         end
       end
 
-      context '無効なイベントを作成しようとしたとき' do
+      context '不正なパラメータのイベントを作成しようとしたとき' do
+        let(:invalid_event) { {
+          name: '',
+          place: '',
+          content: '',
+          start_time: nil,
+          end_time: nil
+        } }
+
         before do
           user = User.create(
             provider: 'twitter',
@@ -69,37 +77,17 @@ RSpec.describe EventsController, type: :controller do
         end
 
         it '#new を再描画すること' do
-          post :create, event: {
-            name: '',
-            place: '',
-            content: '',
-            start_time: nil,
-            end_time: nil
-          }
+          post :create, event: invalid_event
           expect(response).to render_template :new
         end
 
         it 'ステータスコードとして400が返ってくること' do
-          post :create, event: {
-            name: '',
-            place: '',
-            content: '',
-            start_time: nil,
-            end_time: nil
-          }
+          post :create, event: invalid_event
           expect(response.status).to eq 400
         end
 
         it 'イベントがデータベースに追加されていないこと' do
-          expect{
-            post :create, event: {
-            name: '',
-            place: '',
-            content: '',
-            start_time: nil,
-            end_time: nil
-            }
-          }.not_to change(Event, :count)
+          expect{ post :create, event: invalid_event }.not_to change(Event, :count)
         end
       end
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe EventsController, type: :controller do
 
   describe 'POST #create' do
     describe '正常系' do
+      before do
+        user = User.create(
+          provider: 'twitter',
+          uid: 'uid',
+          nickname: 'nickname',
+          image_url: 'http://example.jp/image.jpg'
+        )
+        session[:user_id] = user.id
+      end
       let(:end_time) { Date.today }
 
       context '有効なイベントを作成しようとしたとき' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -52,8 +52,7 @@ RSpec.describe EventsController, type: :controller do
       end
 
       context '無効なイベントを作成しようとしたとき' do
-        pending '#new に遷移すること' do
-        end
+        pending '#new に遷移すること'
       end
     end
   end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe EventsController, type: :controller do
           expect(session['flash']['flashes']['notice']).to eq '作成しました'
         end
 
-        it '@eventにイベントが追加されること' do
+        it 'データベースにイベントが追加されること' do
           created_event = Event.find(assigns[:event])
           expect(created_event).to be_present
         end
@@ -67,7 +67,13 @@ RSpec.describe EventsController, type: :controller do
           )
           session[:user_id] = user.id
 
-          post :create, event: {}
+          post :create, event: {
+            name: '',
+            place: '',
+            content: '',
+            start_time: nil,
+            end_time: nil
+          }
         end
 
         it '#new に遷移すること' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -10,4 +10,23 @@ RSpec.describe EventsController, type: :controller do
       end
     end
   end
+
+  describe 'POST #create' do
+    describe '正常系' do
+      context '有効なイベントを作成しようとしたとき' do
+        it '#show にリダイレクトすること' do
+        end
+
+        it 'notice を渡していること' do
+        end
+      end
+    end
+
+    describe '異常系' do
+      context '無効なイベントを作成しようとしたとき' do
+        it '#new に遷移すること' do
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -36,8 +36,9 @@ RSpec.describe EventsController, type: :controller do
           expect(response).to redirect_to event_path(assigns[:event])
         end
 
-        it 'notice を渡していること' do
-        end
+        pending 'notice を渡していること'
+
+        pending '@eventにイベントが追加されること'
       end
     end
 
@@ -51,7 +52,7 @@ RSpec.describe EventsController, type: :controller do
       end
 
       context '無効なイベントを作成しようとしたとき' do
-        it '#new に遷移すること' do
+        pending '#new に遷移すること' do
         end
       end
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe EventsController, type: :controller do
     end
 
     describe '異常系' do
+      context '未ログインユーザがアクセスしたとき' do
+        before { post :create }
+
+        it 'トップページにリダイレクトすること' do
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
       context '無効なイベントを作成しようとしたとき' do
         it '#new に遷移すること' do
         end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -37,9 +37,14 @@ RSpec.describe EventsController, type: :controller do
           expect(response).to redirect_to event_path(assigns[:event])
         end
 
-        pending 'notice を渡していること'
+        it 'notice を渡していること' do
+          expect(session['flash']['flashes']['notice']).to eq '作成しました'
+        end
 
-        pending '@eventにイベントが追加されること'
+        it '@eventにイベントが追加されること' do
+          created_event = Event.find(assigns[:event])
+          expect(created_event).to be_present
+        end
       end
     end
 
@@ -53,7 +58,21 @@ RSpec.describe EventsController, type: :controller do
       end
 
       context '無効なイベントを作成しようとしたとき' do
-        pending '#new に遷移すること'
+        before do
+          user = User.create(
+            provider: 'twitter',
+            uid: 'uid',
+            nickname: 'nickname',
+            image_url: 'http://example.jp/image.jpg'
+          )
+          session[:user_id] = user.id
+
+          post :create, event: {}
+        end
+
+        it '#new に遷移すること' do
+          expect(response).to redirect_to new_event_path
+        end
       end
     end
   end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe EventsController, type: :controller do
 
   describe 'POST #create' do
     describe '正常系' do
+      let(:end_time) { Date.today }
+
       context '有効なイベントを作成しようとしたとき' do
         it '#show にリダイレクトすること' do
           post :create, event: {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,8 @@ RSpec.configure do |config|
     })
   end
 
+  config.include FactoryGirl::Syntax::Methods
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods


### PR DESCRIPTION
# やりたいこと

ログイン状態管理処理と、イベントの登録用アクション(`events#create`)を追加する。
## ログイン状態管理

ログインしていない場合、「ログインしてください」というアラートと共にトップページへ飛ばしたい。
ログインしている場合は特になにもしない。
これは`events#new`と`events#create`について行う。
## イベント登録処理

イベントの新規登録をできるようにする。
本来はブラウザ上のフォームに必要事項を入力して登録するが、
ひとまずビューはおいておき、パラメータとして与えられたイベント名等を使用し、
`events#create`に対するリクエストが通るようにする。

※ ビューはまた別枠で作成する

※ FactoryGirlを使用したテストへの修正は別PRで行う
# やること
- [x] eventsコントローラのテストを作成
  - [x] ログインしていないユーザがアクセスした時
  - [x] トップページへリダイレクトすること
  - applicationコントローラのテストではない
  - events内でapplicationコントローラの機能を使っているため
- [x] `events#new`アクションを作る
- [x] `app/views/events/new.html.erb`を作成
- [x] ログイン状態判定処理をapplication_controllerに追加
- [x] イベント登録機能(Events#create)を作成
  - `create`したら、作成したイベントの`show`にリダイレクトする
  - `create`に失敗したら作成したイベントの`new`を再描画する
  - 再描画の際はステータスコード`400`を返すようにする
  - レコードが追加されていないことを確認する
