### PR TITLE
event#showのビューにBootstrapを使い、見やすくする

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ActiveRecord::Base
+  belongs_to :owner, class_name: 'User'
+
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -26,3 +26,5 @@
     .panel-body
       = @event.start_time.to_s
       = @event.end_time.to_s
+
+  = link_to '戻る', events_path, class: "btn btn-primary"

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -25,9 +25,10 @@
 
   .panel.panel-default
     .panel-heading
-      | 開催時間
+      | 開催期間
     .panel-body
-      = @event.start_time.to_s
-      = @event.end_time.to_s
+      = @event.start_time.strftime('%Y/%m/%d %H:%M')
+      | 〜
+      = @event.end_time.strftime('%Y/%m/%d %H:%M')
 
   = link_to '戻る', events_path, class: "btn btn-primary"

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -1,13 +1,28 @@
-.container
-  .id
-    = @event.id
-  .name
+.page-header
+  h1.name
     = @event.name
-  .place
-    = @event.place
-  .content
-    = @event.content
-  .start_time
-    = @event.start_time.to_s
-  .end_time
-    = @event.end_time.to_s
+.container
+  .panel.panel-default
+    .panel-heading
+      | 主催者
+    .panel-body
+      = @event.owner_id
+
+  .panel.panel-default
+    .panel-heading
+      | 開催場所
+    .panel-body
+      = @event.place
+
+  .panel.panel-default
+    .panel-heading
+      | イベント内容
+    .panel-body
+      = @event.content
+
+  .panel.panel-default
+    .panel-heading
+      | 開催時間
+    .panel-body
+      = @event.start_time.to_s
+      = @event.end_time.to_s

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -6,7 +6,10 @@
     .panel-heading
       | 主催者
     .panel-body
-      = @event.owner_id
+      = link_to "https://twitter.com/#{User.find(@event.owner_id).nickname}" do
+        = image_tag User.find(@event.owner_id).image_url
+        |  @
+        = User.find(@event.owner_id).nickname
 
   .panel.panel-default
     .panel-heading

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -6,10 +6,10 @@
     .panel-heading
       | 主催者
     .panel-body
-      = link_to "https://twitter.com/#{User.find(@event.owner_id).nickname}" do
-        = image_tag User.find(@event.owner_id).image_url
+      = link_to "https://twitter.com/#@event.owner.nickname}" do
+        = image_tag @event.owner.image_url
         |  @
-        = User.find(@event.owner_id).nickname
+        = @event.owner.nickname
 
   .panel.panel-default
     .panel-heading

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :event do
+    owner
     sequence(:name) { |i| "イベント名#{i}" }
     sequence(:place) { |i| "イベント開催場所#{i}" }
     sequence(:content) { |i| "イベント本文#{i}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,4 +5,11 @@ FactoryGirl.define do
     sequence(:nickname) { |i| "nickname#{i}" }
     sequence(:image_url) { |i| "http://example.com/image#{i}.jpg" }
   end
+
+  trait :broken_peter do
+    provider 'twitter'
+    uid '2351441480'
+    nickname 'broken_peter'
+    image_url 'http://pbs.twimg.com/profile_images/714115257082515456/QakmXenG_normal.jpg'
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,12 +1,12 @@
 FactoryGirl.define do
-  factory :user do
+  factory :user, aliases: [:owner] do
     provider 'twitter'
     sequence(:uid) { |i| "uid#{i}" }
     sequence(:nickname) { |i| "nickname#{i}" }
     sequence(:image_url) { |i| "http://example.com/image#{i}.jpg" }
   end
 
-  trait :broken_peter do
+  trait :active_user do
     provider 'twitter'
     uid '2351441480'
     nickname 'broken_peter'

--- a/spec/features/create_events_spec.rb
+++ b/spec/features/create_events_spec.rb
@@ -35,11 +35,7 @@ RSpec.feature "CreateEvents", type: :feature do
         end
 
         it '登録したイベントの詳細ページに遷移すること' do
-          expect(page).to have_content 'testname'
-          expect(page).to have_content 'testplace'
-          expect(page).to have_content 'testcontent'
-          expect(page).to have_content '2016-06-06 00:00:00 +0900'
-          expect(page).to have_content '2017-06-06 00:00:00 +0900'
+          expect(page).to have_content sample_event.name
         end
       end
     end

--- a/spec/features/create_events_spec.rb
+++ b/spec/features/create_events_spec.rb
@@ -16,20 +16,21 @@ RSpec.feature "CreateEvents", type: :feature do
       end
 
       context 'イベントの登録に成功したとき' do
+        let(:sample_event) { build(:event) }
         before do
-          fill_in 'event_name', with: 'testname'
-          fill_in 'event_place', with: 'testplace'
-          fill_in 'event_content', with: 'testcontent'
-          select '2016', from: 'event_start_time_1i'
-          select '6月', from: 'event_start_time_2i'
-          select '6', from: 'event_start_time_3i'
-          select '00', from: 'event_start_time_4i'
-          select '00', from: 'event_start_time_5i'
-          select '2017', from: 'event_end_time_1i'
-          select '6月', from: 'event_end_time_2i'
-          select '6', from: 'event_end_time_3i'
-          select '00', from: 'event_end_time_4i'
-          select '00', from: 'event_end_time_5i'
+          fill_in 'event_name', with: sample_event.name
+          fill_in 'event_place', with: sample_event.place
+          fill_in 'event_content', with: sample_event.content
+          select sample_event.start_time.year, from: 'event_start_time_1i'
+          select "#{sample_event.start_time.month}月", from: 'event_start_time_2i'
+          select sample_event.start_time.day, from: 'event_start_time_3i'
+          select sample_event.start_time.strftime("%H"), from: 'event_start_time_4i'
+          select sample_event.start_time.strftime("%M"), from: 'event_start_time_5i'
+          select sample_event.end_time.year, from: 'event_end_time_1i'
+          select "#{sample_event.end_time.month}月", from: 'event_end_time_2i'
+          select sample_event.end_time.day, from: 'event_end_time_3i'
+          select sample_event.end_time.strftime("%H"), from: 'event_end_time_4i'
+          select sample_event.end_time.strftime("%M"), from: 'event_end_time_5i'
           click_button '作成'
         end
 

--- a/spec/features/event_shows_spec.rb
+++ b/spec/features/event_shows_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.feature "EventShows", type: :feature do
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/features/event_shows_spec.rb
+++ b/spec/features/event_shows_spec.rb
@@ -1,5 +1,29 @@
 require 'rails_helper'
 
 RSpec.feature "EventShows", type: :feature do
-  pending "add some scenarios (or delete) #{__FILE__}"
+  describe 'ユーザがイベント詳細を閲覧する' do
+    describe '正常系' do
+      context 'あるイベントの詳細にアクセスしたとき' do
+        it '正しいイベント名が表示されていること' do
+        end
+
+        it '正しい主催者が表示されていること' do
+        end
+
+        it '正しい開催場所が表示されていること' do
+        end
+
+        it '正しいイベント内容が表示されていること' do
+        end
+
+        it '正しい開始/終了時刻が表示されていること' do
+        end
+
+        context '戻るボタンをクリックしたとき' do
+          it 'イベント一覧ページに遷移すること' do
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/features/event_shows_spec.rb
+++ b/spec/features/event_shows_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "EventShows", type: :feature do
         end
 
         it '正しい開催場所が表示されていること' do
-          except(page).to have_content sample_event.place
+          expect(page).to have_content sample_event.place
         end
 
         it '正しいイベント内容が表示されていること' do

--- a/spec/features/event_shows_spec.rb
+++ b/spec/features/event_shows_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.feature "EventShows", type: :feature do
   describe 'ユーザがイベント詳細を閲覧する' do
     describe '正常系' do
-      let(:sample_event) { create(:event) }
+      let(:sample_event) { create(:event, owner_id: 1) }
       before do
+        create(:user, :broken_peter)
         visit event_path(sample_event.id)
       end
 
@@ -14,8 +15,7 @@ RSpec.feature "EventShows", type: :feature do
         end
 
         it '正しい主催者が表示されていること' do
-          binding.pry
-          expect(page).to have_content sample_event.owner_id
+          expect(page).to have_content User.find(sample_event.owner_id).nickname
         end
 
         it '正しい開催場所が表示されていること' do

--- a/spec/features/event_shows_spec.rb
+++ b/spec/features/event_shows_spec.rb
@@ -27,8 +27,8 @@ RSpec.feature "EventShows", type: :feature do
         end
 
         it '正しい開始/終了時刻が表示されていること' do
-          expect(page).to have_content sample_event.start_time
-          expect(page).to have_content sample_event.end_time
+          expect(page).to have_content sample_event.start_time.strftime('%Y/%m/%d %H:%M')
+          expect(page).to have_content sample_event.end_time.strftime('%Y/%m/%d %H:%M')
         end
 
         context '戻るボタンをクリックしたとき' do

--- a/spec/features/event_shows_spec.rb
+++ b/spec/features/event_shows_spec.rb
@@ -33,7 +33,8 @@ RSpec.feature "EventShows", type: :feature do
 
         context '戻るボタンをクリックしたとき' do
           it 'イベント一覧ページに遷移すること' do
-            expect(page.current_url).to eq events_path
+            click_on '戻る'
+            expect(page.current_path).to eq events_path
           end
         end
       end

--- a/spec/features/event_shows_spec.rb
+++ b/spec/features/event_shows_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.feature "EventShows", type: :feature do
   describe 'ユーザがイベント詳細を閲覧する' do
     describe '正常系' do
-      let(:sample_event) { create(:event, owner_id: 1) }
+      let(:owner) { create(:user, :active_user) }
+      let(:sample_event) { create(:event, owner: owner) }
       before do
-        create(:user, :broken_peter)
         visit event_path(sample_event.id)
       end
 
@@ -15,7 +15,7 @@ RSpec.feature "EventShows", type: :feature do
         end
 
         it '正しい主催者が表示されていること' do
-          expect(page).to have_content User.find(sample_event.owner_id).nickname
+          expect(page).to have_content sample_event.owner.nickname
         end
 
         it '正しい開催場所が表示されていること' do

--- a/spec/features/event_shows_spec.rb
+++ b/spec/features/event_shows_spec.rb
@@ -3,24 +3,37 @@ require 'rails_helper'
 RSpec.feature "EventShows", type: :feature do
   describe 'ユーザがイベント詳細を閲覧する' do
     describe '正常系' do
+      let(:sample_event) { create(:event) }
+      before do
+        visit event_path(sample_event.id)
+      end
+
       context 'あるイベントの詳細にアクセスしたとき' do
         it '正しいイベント名が表示されていること' do
+          expect(page).to have_content sample_event.name
         end
 
         it '正しい主催者が表示されていること' do
+          binding.pry
+          expect(page).to have_content sample_event.owner_id
         end
 
         it '正しい開催場所が表示されていること' do
+          except(page).to have_content sample_event.place
         end
 
         it '正しいイベント内容が表示されていること' do
+          expect(page).to have_content sample_event.content
         end
 
         it '正しい開始/終了時刻が表示されていること' do
+          expect(page).to have_content sample_event.start_time
+          expect(page).to have_content sample_event.end_time
         end
 
         context '戻るボタンをクリックしたとき' do
           it 'イベント一覧ページに遷移すること' do
+            expect(page.current_url).to eq events_path
           end
         end
       end


### PR DESCRIPTION
# やりたいこと

`show`アクションで表示されるイベント詳細画面が、
仮状態だとイベントの名前、場所などをただ表示しているだけなので、
Bootstrapを適用して表示を綺麗に、見やすくする。

また、イベントの主催者に関する情報も追加し、
Twitterからアイコンを取得、それを表示する。
# やること
- [x] フィーチャスペックを記述
  - イベント詳細、名前や内容といった要素がページ内に含まれているか
  - イベント一覧ページに戻る機能が欲しい気がする(パRails外)
- [x] ビューを修正
# 変更結果
## びふぉー

<img width="1258" alt="2016-06-10 11 38 17" src="https://cloud.githubusercontent.com/assets/5087172/15952903/0fe58a82-2f00-11e6-83f8-df5433b37fd7.png">
## あふたー

<img width="1230" alt="2016-06-10 11 39 04" src="https://cloud.githubusercontent.com/assets/5087172/15952909/1739681c-2f00-11e6-8253-c16017e6e0b3.png">
