### PR TITLE
[WIP] イベント一覧表示のためのindexアクションを追加する

### DIFF
--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -12,6 +12,28 @@ RSpec.describe EventsController, type: :controller do
   end
 
   describe 'GET #index' do
+    describe '正常系' do
+      context 'イベント一覧を取得したとき' do
+        it 'ステータスコード200が返ること' do
+        end
+
+        it 'indexテンプレートがレンダリングされること' do
+        end
+
+        it '未開催のイベントが全て取得できること' do
+          # 取得できたイベントの件数が意図したものと同数であればOK？
+          # 件数チェック＋開始時刻チェック？
+        end
+
+        it '開催済みのイベントが含まれないこと' do
+          # ここは件数チェック不要？
+          # 全イベントの開始時刻と現在時刻を総当りでチェックするだけ？
+        end
+      end
+    end
+
+    describe '異常系' do
+    end
   end
 
   describe 'GET #show' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe EventsController, type: :controller do
           # 全イベントの開始時刻と現在時刻を総当りでチェックするだけ？
         end
       end
+
+      context '未開催のイベントが1件もないとき' do
+        it 'ステータスコード200が返ること' do
+        end
+
+        it 'indexテンプレートがレンダリングされること' do
+        end
+
+        it '取得したイベントの件数が0件であること' do
+        end
+      end
     end
 
     describe '異常系' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe EventsController, type: :controller do
     end
   end
 
+  describe 'GET #index' do
+  end
+
   describe 'GET #show' do
     describe '正常系' do
       context '存在するイベントを表示しようとしたとき' do


### PR DESCRIPTION
# やりたいこと

イベント一覧ページを表示するため、現在登録されているイベント一覧を取得するための
indexアクションを作成する。

表示するイベントはひとまず未開催のもののみとする。
未開催の定義は、イベント開始時刻が現在時刻より後であることとする。

（開催中のものも入れたい気もするが、ややこしくなりそうなのでひとまず未開催に絞る）
# やること
- [ ] indexアクションに対するテストの作成
  - [ ] イベントを複数件createする必要がある
  - 未開催、開催中、開催後、現在時刻と開催時刻が同じもの
  - 他のテストで作ったイベントが混ざるとややこしいかもしれない
  - 一回イベントをクリアする必要があるかも？
- [ ] indexアクションの実装
